### PR TITLE
fix: CloudAdapter don't work with Teams SSO

### DIFF
--- a/samples/bot-conversation-sso-quickstart/js/bots/teamsBot.js
+++ b/samples/bot-conversation-sso-quickstart/js/bots/teamsBot.js
@@ -36,6 +36,12 @@ class TeamsBot extends DialogBot {
         console.log('Running dialog with signin/verifystate from an Invoke Activity.');
         await this.dialog.run(context, this.dialogState);
     }
+
+    async handleTeamsSigninTokenExchange(context, query) {
+        console.log('Running dialog with signin/tokenExchange from an Invoke Activity.');
+        await this.dialog.run(context, this.dialogState);
+    }
+
 }
 
 module.exports.TeamsBot = TeamsBot;


### PR DESCRIPTION
Fixes # 4408

## Description
This PR updates the [bot-conversation-sso-quickstart-js](https://github.com/OfficeDev/Microsoft-Teams-Samples/tree/main/samples/bot-conversation-sso-quickstart/js) to work with _**CloudAdapter**_.

## Specific Changes
- Added _handleTeamsSigninTokenExchange_ handler in teamsBot.js.

## Testing
This screenshot shows the bot working with its changes and the SDK ones.
<img width="765" alt="VGDrXpFnqb" src="https://user-images.githubusercontent.com/64815358/215850613-2ae6cde7-ae31-4a37-b7e3-87edb3c3d98c.png">

